### PR TITLE
feat: add passport card setup

### DIFF
--- a/apps/docs/pages/changelog/S26.mdx
+++ b/apps/docs/pages/changelog/S26.mdx
@@ -11,6 +11,7 @@ Spring term work across the main website, admin tools, event tech, CxC, and shar
 ## 🔧 Infrastructure
 
 - **Password Reset Tracking**: Admins can now monitor password reset activity with lifetime and per-term reset counters stored for each user. The membership table unique constraint was updated to track resets per semester.
+- **Mark as Paid with Event Check-in**: Admins can now mark a member as paid and optionally check them into the active event in one action, streamlining payment verification at events.
 
 ---
 

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { PassportHeader, MembershipCta, PassportProfile } from "@/components/passport";
+import { PassportCard, MembershipCta, PassportProfile } from "@/components/passport";
 import { useAuth } from "@/contexts/AuthContext";
 import { getMembershipStatus, updateUserProfile } from "@/lib/api/profile";
 import { FACULTY_LABELS, FACULTY_PROFILE_LABEL_TO_VALUE } from "@uwdsc/common/constants";
@@ -93,13 +93,15 @@ export default function PassportPage() {
   return (
     <main className="flex min-h-dvh flex-col items-center px-4 pb-16 pt-28 lg:pt-32">
       <div className="w-full max-w-2xl space-y-4">
-        <PassportHeader
+        <PassportCard
           initials={initials}
           displayName={displayName}
           email={user?.email}
           membershipLoading={membershipLoading}
           isMember={!!isMember}
           execPositionLabel={user?.exec_position_name}
+          facultyLabel={facultyLabel}
+          term={user?.term ?? undefined}
         />
 
         <PassportProfile

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -3,13 +3,14 @@
 import { NavLinks } from "./navbar/NavLinks";
 import { UserAvatar } from "./navbar/UserAvatar";
 import { MobileMenu } from "./navbar/MobileMenu";
+import { WrappedModal } from "./wrapped/WrappedModal"
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { getApplyWindowOpen } from "@/lib/api";
 import Image from "next/image";
 import Link from "next/link";
 import { ADMIN_ROLES } from "@uwdsc/common/constants";
-import { GlassSurface, NavigationMenu, NavigationMenuList } from "@uwdsc/ui";
+import { GlassSurface, NavigationMenu, NavigationMenuList, Button, NavigationMenuItem } from "@uwdsc/ui";
 import { useEffect, useState } from "react";
 
 const hideNavbarPaths = new Set(["/login", "/register", "/complete-profile"]);
@@ -18,6 +19,7 @@ export function Navbar() {
   const pathname = usePathname();
   const { user } = useAuth();
   const [applyInNav, setApplyInNav] = useState(false);
+  const [wrappedOpen, setWrappedOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -82,6 +84,14 @@ export function Navbar() {
             <NavigationMenu viewport={false}>
               <NavigationMenuList className="gap-4">
                 <NavLinks navLinks={navLinks} />
+                <NavigationMenuItem>
+                  <Button 
+                    variant="ghost"
+                    onClick={() => setWrappedOpen(true)}
+                    className="h-10 flex flex-row items-center gap-2 px-4 rounded-md hover:text-nav-hover-blue">
+                      <span className="text-sm font-medium">Wrapped</span>
+                    </Button>
+                </NavigationMenuItem>
                 <UserAvatar />
               </NavigationMenuList>
             </NavigationMenu>
@@ -89,8 +99,9 @@ export function Navbar() {
         </div>
 
         {/* Mobile Menu */}
-        <MobileMenu navLinks={navLinks} user={user} />
+        <MobileMenu navLinks={navLinks} user={user} onOpenWrapped={() => setWrappedOpen(true)}/>
       </div>
+      <WrappedModal open={wrappedOpen} onOpenChange={setWrappedOpen} />
     </div>
   );
 }

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -84,6 +84,7 @@ export function Navbar() {
             <NavigationMenu viewport={false}>
               <NavigationMenuList className="gap-4">
                 <NavLinks navLinks={navLinks} />
+                {process.env.NODE_ENV === 'development' && (
                 <NavigationMenuItem>
                   <Button 
                     variant="ghost"
@@ -92,6 +93,7 @@ export function Navbar() {
                       <span className="text-sm font-medium">Wrapped</span>
                     </Button>
                 </NavigationMenuItem>
+                )}
                 <UserAvatar />
               </NavigationMenuList>
             </NavigationMenu>

--- a/apps/web/components/navbar/MobileMenu.tsx
+++ b/apps/web/components/navbar/MobileMenu.tsx
@@ -110,12 +110,14 @@ export function MobileMenu({ navLinks, user, onOpenWrapped }: Readonly<MobileMen
             {/* Main Navigation Links */}
             <div className="px-6 py-2">
               <nav className="space-y-1">
+                {process.env.NODE_ENV === 'development' && (
                 <Button 
                     variant="ghost"
                     onClick={handleOpenWrapped}
                     className="w-full justify-start text-lg py-3 px-4 h-auto font-semibold hover:bg-accent/50 transition-colors rounded-lg gap-2">
                       <span className="text-sm font-medium">Wrapped</span>
                     </Button>
+                  )}
                 {navLinks.map((link) => {
                   const linkComponent = (
                     <Link

--- a/apps/web/components/navbar/MobileMenu.tsx
+++ b/apps/web/components/navbar/MobileMenu.tsx
@@ -29,6 +29,7 @@ interface NavLink {
 interface MobileMenuProps {
   navLinks: NavLink[];
   user: Profile | null;
+  onOpenWrapped?: () => void;
 }
 
 function HamburgerIcon() {
@@ -41,7 +42,7 @@ function HamburgerIcon() {
   );
 }
 
-export function MobileMenu({ navLinks, user }: Readonly<MobileMenuProps>) {
+export function MobileMenu({ navLinks, user, onOpenWrapped }: Readonly<MobileMenuProps>) {
   const router = useRouter();
   const { mutate } = useAuth();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -56,6 +57,11 @@ export function MobileMenu({ navLinks, user }: Readonly<MobileMenuProps>) {
     } catch (error) {
       console.error("Failed to sign out:", error);
     }
+  };
+
+  const handleOpenWrapped = () => {
+    setIsMobileMenuOpen(false);
+    onOpenWrapped?.();
   };
 
   return (
@@ -104,6 +110,12 @@ export function MobileMenu({ navLinks, user }: Readonly<MobileMenuProps>) {
             {/* Main Navigation Links */}
             <div className="px-6 py-2">
               <nav className="space-y-1">
+                <Button 
+                    variant="ghost"
+                    onClick={handleOpenWrapped}
+                    className="w-full justify-start text-lg py-3 px-4 h-auto font-semibold hover:bg-accent/50 transition-colors rounded-lg gap-2">
+                      <span className="text-sm font-medium">Wrapped</span>
+                    </Button>
                 {navLinks.map((link) => {
                   const linkComponent = (
                     <Link

--- a/apps/web/components/passport/PassportCard.tsx
+++ b/apps/web/components/passport/PassportCard.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import Image from "next/image";
+import { useRef, useState, useEffect } from "react";
+import {
+  motion,
+  useMotionValue,
+  useSpring,
+  useTransform,
+  type MotionValue,
+} from "framer-motion";
+
+interface PassportCardProps {
+  readonly initials: string;
+  readonly displayName: string;
+  readonly email: string | null | undefined;
+  readonly facultyLabel?: string;
+  readonly term?: string;
+  readonly isMember: boolean;
+  readonly membershipLoading: boolean;
+  readonly execPositionLabel?: string | null;
+}
+
+const CARD_BG = {
+  background:
+    "linear-gradient(160deg, oklch(0.17 0.07 292) 0%, oklch(0.13 0.04 285) 100%)",
+};
+
+const W = 260;
+const H = W * 1.5; // 390 — never changes
+
+function buildMrz(displayName: string, term?: string): [string, string] {
+  const cleaned = displayName.toUpperCase().replace(/[^A-Z ]/g, "");
+  const parts = cleaned.split(" ");
+  const surname = (parts[parts.length - 1] ?? "MEMBER").slice(0, 9).padEnd(9, "<");
+  const given = (parts.slice(0, -1).join("<") || "MEMBER").slice(0, 9).padEnd(9, "<");
+  const termStr = (term ?? "")
+    .replace(/[^A-Z0-9]/gi, "")
+    .slice(0, 4)
+    .padEnd(4, "<")
+    .toUpperCase();
+  const line1 = `P<UWDSC${surname}<<${given}`.slice(0, 44).padEnd(44, "<");
+  const line2 = `MEMBER01<UWDSC${termStr}<<<<<<<<<<<<<<<<<<<<<<`
+    .slice(0, 44)
+    .padEnd(44, "<");
+  return [line1, line2];
+}
+
+function MemberBadge({
+  isMember,
+  membershipLoading,
+}: {
+  isMember: boolean;
+  membershipLoading: boolean;
+}) {
+  if (membershipLoading)
+    return (
+      <span
+        className="h-3 w-16 rounded-sm inline-block"
+        style={{ background: "rgba(255,255,255,0.1)" }}
+      />
+    );
+  if (isMember)
+    return (
+      <span className="text-[7px] font-bold px-1.5 py-0.5 rounded-sm bg-emerald-400/15 text-emerald-300 border border-emerald-400/25 tracking-widest uppercase">
+        Active
+      </span>
+    );
+  return (
+    <span className="text-[7px] font-bold px-1.5 py-0.5 rounded-sm bg-red-400/15 text-red-400 border border-red-400/25 tracking-widest uppercase">
+      Not Paid
+    </span>
+  );
+}
+
+function BioPage({
+  initials,
+  displayName,
+  email,
+  facultyLabel,
+  term,
+  isMember,
+  membershipLoading,
+  execPositionLabel,
+}: PassportCardProps) {
+  const [mrzLine1, mrzLine2] = buildMrz(displayName, term);
+  const nameParts = displayName.toUpperCase().split(" ");
+  const surname = nameParts[nameParts.length - 1] ?? displayName.toUpperCase();
+  const givenNames = nameParts.slice(0, -1).join(" ") || displayName.toUpperCase();
+
+  return (
+    <div
+      className="relative w-full h-full flex flex-col select-none overflow-hidden"
+      style={CARD_BG}
+    >
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage: "url('/logos/dsc.svg')",
+          backgroundSize: "44px 44px",
+          backgroundRepeat: "repeat",
+          opacity: 0.03,
+        }}
+      />
+      <div className="absolute -top-8 -right-8 size-32 rounded-full bg-primary/20 blur-2xl pointer-events-none" />
+      <div className="relative z-10 flex items-center justify-between px-3 pt-3 pb-2">
+        <span className="text-white font-mono font-bold text-[9px] tracking-[0.16em]">UWDSC</span>
+        <span className="text-white/25 font-mono text-[6px] tracking-[0.2em] uppercase">Data Science</span>
+      </div>
+      <div className="mx-3 h-px bg-white/10" />
+      <div className="relative z-10 flex gap-2 px-3 pt-2.5 flex-1">
+        <div className="shrink-0 flex flex-col items-start gap-1.5">
+          <div className="w-9 h-11 border border-white/20 rounded-sm bg-white/5 flex items-center justify-center text-white font-bold text-sm">
+            {initials}
+          </div>
+          <MemberBadge isMember={isMember} membershipLoading={membershipLoading} />
+        </div>
+        <div className="flex-1 min-w-0 space-y-1.5">
+          <div>
+            <p className="text-white/25 font-mono text-[5.5px] tracking-[0.2em] uppercase mb-0.5">Surname</p>
+            <p className="text-white font-mono text-[9px] tracking-wider truncate">{surname}</p>
+          </div>
+          <div>
+            <p className="text-white/25 font-mono text-[5.5px] tracking-[0.2em] uppercase mb-0.5">Given Names</p>
+            <p className="text-white font-mono text-[9px] tracking-wider truncate">{givenNames}</p>
+          </div>
+          {facultyLabel && (
+            <div>
+              <p className="text-white/25 font-mono text-[5.5px] tracking-[0.2em] uppercase mb-0.5">Faculty</p>
+              <p className="text-white font-mono text-[9px] tracking-wider">{facultyLabel.toUpperCase()}</p>
+            </div>
+          )}
+          {term && (
+            <div>
+              <p className="text-white/25 font-mono text-[5.5px] tracking-[0.2em] uppercase mb-0.5">Term</p>
+              <p className="text-white font-mono text-[9px] tracking-wider">{term.toUpperCase()}</p>
+            </div>
+          )}
+          {execPositionLabel && (
+            <div>
+              <p className="text-white/25 font-mono text-[5.5px] tracking-[0.2em] uppercase mb-0.5">Position</p>
+              <p className="text-primary/80 font-mono text-[9px] tracking-wider truncate">{execPositionLabel.toUpperCase()}</p>
+            </div>
+          )}
+        </div>
+      </div>
+      {email && (
+        <p className="relative z-10 px-3 pt-1.5 text-white/20 font-mono text-[6px] truncate">{email}</p>
+      )}
+      <div className="relative z-10 mt-auto">
+        <div className="mx-3 h-px bg-white/10 mb-1.5 mt-2" />
+        <div className="px-2.5 pb-2.5 space-y-0.5">
+          <p className="text-white/15 font-mono text-[5px] tracking-[0.03em] truncate">{mrzLine1}</p>
+          <p className="text-white/15 font-mono text-[5px] tracking-[0.03em] truncate">{mrzLine2}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StampsPage() {
+  return (
+    <div
+      className="relative w-full h-full flex flex-col select-none overflow-hidden"
+      style={CARD_BG}
+    >
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage: "url('/logos/dsc.svg')",
+          backgroundSize: "44px 44px",
+          backgroundRepeat: "repeat",
+          opacity: 0.03,
+        }}
+      />
+      <div className="absolute -bottom-8 -left-8 size-28 rounded-full bg-primary/15 blur-2xl pointer-events-none" />
+      <div className="relative z-10 flex items-center justify-between px-3 pt-3 pb-2">
+        <span className="text-white/30 font-mono text-[6px] tracking-[0.2em] uppercase">Stamps</span>
+        <span className="text-white/15 font-mono text-[6px]">0</span>
+      </div>
+      <div className="mx-3 h-px bg-white/10" />
+      <div className="relative z-10 px-3 pt-3 grid grid-cols-3 gap-1.5">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div
+            key={i}
+            className="aspect-square rounded border border-dashed border-white/10 flex items-center justify-center"
+          >
+            <span className="text-white/10 font-mono text-[10px]">+</span>
+          </div>
+        ))}
+      </div>
+      <p className="relative z-10 mt-auto pb-3 text-center text-white/15 font-mono text-[6px] tracking-[0.16em] uppercase">
+        No events yet
+      </p>
+    </div>
+  );
+}
+
+function Cover({ shine }: { shine: MotionValue<string> }) {
+  return (
+    <div
+      className="relative w-full h-full flex flex-col items-center justify-center select-none overflow-hidden"
+      style={CARD_BG}
+    >
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage: "url('/logos/dsc.svg')",
+          backgroundSize: "52px 52px",
+          backgroundRepeat: "repeat",
+          opacity: 0.05,
+        }}
+      />
+      <div className="absolute -top-10 -right-8 size-40 rounded-full bg-primary/20 blur-3xl pointer-events-none" />
+      <div className="absolute -bottom-8 -left-8 size-28 rounded-full bg-primary/15 blur-2xl pointer-events-none" />
+      <div className="absolute left-3 inset-y-4 w-px bg-white/10" />
+      <div className="relative z-10 flex flex-col items-center gap-4">
+        <Image src="/logos/dsc.svg" alt="UWDSC" width={52} height={52} />
+        <div className="text-center space-y-1">
+          <p className="text-white font-mono font-bold text-[11px] tracking-[0.18em]">UWDSC</p>
+          <p className="text-white/50 font-mono text-[8px] tracking-[0.22em] uppercase">UWaterloo Data Science</p>
+          <p className="text-white/30 font-mono text-[7px] tracking-[0.28em] uppercase">Club Member</p>
+        </div>
+      </div>
+      <motion.div
+        className="absolute inset-0 pointer-events-none z-20"
+        style={{ background: shine }}
+      />
+    </div>
+  );
+}
+
+export function PassportCard(props: PassportCardProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+
+  const mouseX = useMotionValue(0);
+  const mouseY = useMotionValue(0);
+  const xSpring = useSpring(mouseX, { stiffness: 150, damping: 20 });
+  const ySpring = useSpring(mouseY, { stiffness: 150, damping: 20 });
+  const scaleSpring = useSpring(1, { stiffness: 200, damping: 22 });
+  const tiltX = useTransform(ySpring, [-0.5, 0.5], [6, -6]);
+  const tiltY = useTransform(xSpring, [-0.5, 0.5], [-6, 6]);
+
+  const coverAngle = useMotionValue(0);
+  const coverSpring = useSpring(coverAngle, { stiffness: 90, damping: 20 });
+
+  // Desktop: two-page spread. Mobile: single portrait card.
+  const cardWidth = useTransform(
+    coverSpring,
+    [-180, 0],
+    isMobile ? [W, W] : [W * 2, W]
+  );
+  const cardShift = useTransform(
+    coverSpring,
+    [-180, 0],
+    isMobile ? [0, 0] : [0, W / 2]
+  );
+
+  const rightPageOpacity = useTransform(coverSpring, [-180, -90, 0], [1, 0, 0]);
+
+  // Detect mobile on mount + resize
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 768);
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  const shine = useTransform([xSpring, ySpring], ([x, y]) => {
+    const angle = ((x as number) + 0.5) * 360;
+    const gx = ((x as number) + 0.5) * 100;
+    const gy = ((y as number) + 0.5) * 100;
+    return [
+      `radial-gradient(circle at ${gx}% ${gy}%, rgba(255,255,255,0.10) 0%, transparent 40%)`,
+      `linear-gradient(${angle}deg,` +
+        `hsl(0deg 100% 70%/0.06),hsl(60deg 100% 70%/0.06),` +
+        `hsl(120deg 100% 70%/0.06),hsl(180deg 100% 70%/0.06),` +
+        `hsl(240deg 100% 70%/0.06),hsl(300deg 100% 70%/0.06),` +
+        `hsl(360deg 100% 70%/0.06))`,
+    ].join(", ");
+  });
+
+  const handleClick = () => {
+    const next = !open;
+    setOpen(next);
+    coverAngle.set(next ? -180 : 0);
+  };
+
+  return (
+    <motion.div
+      className="space-y-2"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
+      {/* Positioned right-of-center when closed, shifts to center when open */}
+      <motion.div className="mx-auto" style={{ width: cardWidth, x: cardShift }}>
+        {/*
+         * perspective: 400 — close-up, dramatic depth.
+         * NO overflow-hidden — lets the cover's near edge pop toward the viewer
+         * during the flip, which is what makes it feel physical.
+         */}
+        <div
+          ref={ref}
+          className="relative rounded-2xl shadow-2xl cursor-pointer"
+          style={{ height: H, perspective: 400 }}
+          onClick={handleClick}
+          onMouseMove={(e) => {
+            if (!ref.current) return;
+            const { left, top, width, height } =
+              ref.current.getBoundingClientRect();
+            mouseX.set((e.clientX - left) / width - 0.5);
+            mouseY.set((e.clientY - top) / height - 0.5);
+          }}
+          onMouseEnter={() => scaleSpring.set(1.03)}
+          onMouseLeave={() => {
+            mouseX.set(0);
+            mouseY.set(0);
+            scaleSpring.set(1);
+          }}
+        >
+          <motion.div
+            style={{
+              position: "absolute",
+              inset: 0,
+              rotateX: tiltX,
+              rotateY: tiltY,
+              scale: scaleSpring,
+            }}
+          >
+            {/* Desktop: show stamps page + spine + bio page */}
+            {/* Mobile: only show bio page (stamps live below as separate section) */}
+            {!isMobile && (
+              <>
+                <div className="absolute inset-y-0 left-0" style={{ width: W }}>
+                  <StampsPage />
+                </div>
+                <div
+                  className="absolute inset-y-0 bg-white/15"
+                  style={{ left: W, width: 1 }}
+                />
+              </>
+            )}
+
+            {/* Bio page — desktop: right side of spread. Mobile: behind the cover. */}
+            <motion.div
+              className="absolute inset-y-0"
+              style={
+                isMobile
+                  ? { left: 0, width: W, opacity: rightPageOpacity }
+                  : { left: W + 1, width: W - 1, opacity: rightPageOpacity }
+              }
+            >
+              <BioPage {...props} />
+            </motion.div>
+
+            {/* Cover — the flip. originX:0 hinges it at the spine.
+                No overflow parent means the near edge visibly arcs toward
+                the viewer as it rotates, giving the physical flip feel. */}
+            <div
+              className="absolute inset-y-0 left-0 rounded-2xl"
+              style={{ width: W }}
+            >
+              <motion.div
+                className="absolute inset-0 rounded-2xl"
+                style={{
+                  originX: 0,
+                  rotateY: coverSpring,
+                  transformStyle: "preserve-3d",
+                  translateZ: 1,
+                }}
+              >
+                <div
+                  className="absolute inset-0 rounded-2xl"
+                  style={{ backfaceVisibility: "hidden" }}
+                >
+                  <Cover shine={shine} />
+                </div>
+              </motion.div>
+            </div>
+          </motion.div>
+        </div>
+      </motion.div>
+
+      <p className="text-center text-xs text-muted-foreground">
+        {open ? "Click to close" : "Click to open"}
+      </p>
+    </motion.div>
+  );
+}

--- a/apps/web/components/passport/index.ts
+++ b/apps/web/components/passport/index.ts
@@ -1,3 +1,4 @@
 export * from "./PassportHeader";
 export * from "./MembershipCta";
 export * from "./PassportProfile";
+export * from "./PassportCard";

--- a/apps/web/components/wrapped/WrappedModal.tsx
+++ b/apps/web/components/wrapped/WrappedModal.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { X } from "lucide-react"
+import { Button, Dialog, DialogClose, DialogContent, DialogTitle } from "@uwdsc/ui"
+
+interface WrappedModalProps {
+    readonly open: boolean;
+    readonly onOpenChange: (open: boolean) => void;
+    
+}
+
+export function WrappedModal({ open, onOpenChange }: WrappedModalProps) {
+    return (
+        <Dialog open = {open} onOpenChange={onOpenChange}>
+            <DialogContent
+                showCloseButton={false}
+                className="w-full max-w-[390px] h-[85dvh] max-h-[844px] rounded-3xl border-0 p-0 bg-background overflow-hidden max-sm:max-w-none max-sm:h-[100dvh] max-sm:max-h-none max-sm:rounded-none"
+            >
+                <DialogClose asChild>
+                    <Button variant="ghost" size="icon" 
+                    className="absolute top-4 right-4 z-10 text-white hover:bg-white/10 rounded-full">
+                        <X className="size-5" />
+                        <span className="sr-only">Close</span>
+                    </Button>
+                </DialogClose>
+                 {/* Wrapped content */}
+                <DialogTitle
+                    className="p-8">
+                    Hello !
+                </DialogTitle>
+            </DialogContent>
+        </Dialog>
+    )
+}


### PR DESCRIPTION
<!-- Make sure you add the correct **Assignees** and **Labels** that best fit this pull request -->

<!-- DO NOT forget to add the **label** corresponding to the **current term** (i.e. **W26**) -->

<!-- IMPORTANT: please replace "[issue-number]" with the issue number from the GitHub Project -->

## Closes Issue

closes #85 

<!-- Brief description of what you changed using bullet points -->

## Changes Made

- Created `/apps/web/components/passport/PassportCard.tsx` for 3D flip passport card with
  holographic shine
- Updated `/apps/web/components/passport/index.ts` to export PassportCard
- Modified `/apps/web/app/passport/page.tsx` to use PassportCard instead of
  PassportHeader
- Two different versions of card:
  - For desktop: two-page passport with stamps and bio page that opens from right-of-center to centered
  - For mobile: single portrait card with simple flip to bio page (two page did not fit on screen)

## Additional Notes/Screenshots/Videos (Optional)
