### PR TITLE
Lia/most visited page

### DIFF
--- a/apps/web/app/api/analytics/page-view/route.ts
+++ b/apps/web/app/api/analytics/page-view/route.ts
@@ -1,0 +1,47 @@
+import { ApiResponse } from "@uwdsc/common/utils";
+import { createSupabaseServerClient } from "@uwdsc/db";
+import { cookies } from "next/headers";
+import { NextRequest } from "next/server";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function POST(request: NextRequest): Promise<Response> {
+  try {
+    const body = (await request.json()) as { path?: string; visitor_id?: string };
+    const { path, visitor_id: visitorId } = body;
+
+    if (!path?.startsWith("/")) {
+      return ApiResponse.badRequest("Invalid path");
+    }
+
+    if (!visitorId || !UUID_REGEX.test(visitorId)) {
+      return ApiResponse.badRequest("Invalid visitor_id");
+    }
+
+    const cookieStore = await cookies();
+    const supabase = createSupabaseServerClient({
+      getAll() {
+        return cookieStore.getAll();
+      },
+      set(name: string, value: string, options?) {
+        cookieStore.set(name, value, options);
+      },
+    });
+
+    const { error } = await supabase.rpc("log_page_view", {
+      p_path: path,
+      p_visitor_id: visitorId,
+    });
+
+    if (error) {
+      console.error("Failed to log page view:", error);
+      return ApiResponse.serverError(error, "Failed to log page view");
+    }
+
+    return ApiResponse.ok({ success: true });
+  } catch (error: unknown) {
+    console.error("Page view logging error:", error);
+    return ApiResponse.serverError(error, "Failed to log page view");
+  }
+}

--- a/apps/web/components/tracking/PageViewTracker.tsx
+++ b/apps/web/components/tracking/PageViewTracker.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { createSupabaseBrowserClient } from "@uwdsc/db";
+import { getOrCreateVisitorId } from "@/lib/tracking/visitorId";
+
+export function PageViewTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname) return;
+
+    const visitorId = getOrCreateVisitorId();
+    if (!visitorId) return;
+
+    let cancelled = false;
+
+    const logPageView = async () => {
+      const supabase = createSupabaseBrowserClient();
+      const { error } = await supabase.rpc("log_page_view", {
+        p_path: pathname,
+        p_visitor_id: visitorId,
+      });
+
+      if (cancelled || !error) return;
+
+      console.error("Failed to log page view:", error);
+    };
+
+    void logPageView();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/web/components/tracking/PageViewTracker.tsx
+++ b/apps/web/components/tracking/PageViewTracker.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { createSupabaseBrowserClient } from "@uwdsc/db";
 import { getOrCreateVisitorId } from "@/lib/tracking/visitorId";
 
 export function PageViewTracker() {
@@ -17,15 +16,18 @@ export function PageViewTracker() {
     let cancelled = false;
 
     const logPageView = async () => {
-      const supabase = createSupabaseBrowserClient();
-      const { error } = await supabase.rpc("log_page_view", {
-        p_path: pathname,
-        p_visitor_id: visitorId,
+      const response = await fetch("/api/analytics/page-view", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          path: pathname,
+          visitor_id: visitorId,
+        }),
       });
 
-      if (cancelled || !error) return;
+      if (cancelled || response.ok) return;
 
-      console.error("Failed to log page view:", error);
+      console.error("Failed to log page view:", response.status);
     };
 
     void logPageView();

--- a/apps/web/lib/tracking/visitorId.ts
+++ b/apps/web/lib/tracking/visitorId.ts
@@ -1,0 +1,25 @@
+const VISITOR_ID_STORAGE_KEY = "dsc:visitor-id";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isValidUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+export function getOrCreateVisitorId(): string | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const existing = window.localStorage.getItem(VISITOR_ID_STORAGE_KEY);
+    if (existing && isValidUuid(existing)) {
+      return existing;
+    }
+
+    const visitorId = crypto.randomUUID();
+    window.localStorage.setItem(VISITOR_ID_STORAGE_KEY, visitorId);
+    return visitorId;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/providers/AppProviders.tsx
+++ b/apps/web/providers/AppProviders.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { PageViewTracker } from "@/components/tracking/PageViewTracker";
 import { TooltipProvider, Toaster } from "@uwdsc/ui";
 
 interface AppProvidersProps {
@@ -19,6 +20,7 @@ export function AppProviders({ children }: AppProvidersProps) {
       enableColorScheme
     >
       <AuthProvider>
+        <PageViewTracker />
         <TooltipProvider>{children}</TooltipProvider>
         <Toaster />
       </AuthProvider>

--- a/packages/server/db/src/migrations/20260718000000-page-views.js
+++ b/packages/server/db/src/migrations/20260718000000-page-views.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260718000000-page-views-up.sql');
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260718000000-page-views-down.sql');
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/server/db/src/migrations/20260718100000-page-views-log-rpc.js
+++ b/packages/server/db/src/migrations/20260718100000-page-views-log-rpc.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260718100000-page-views-log-rpc-up.sql');
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260718100000-page-views-log-rpc-down.sql');
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/server/db/src/migrations/sqls/20260718000000-page-views-down.sql
+++ b/packages/server/db/src/migrations/sqls/20260718000000-page-views-down.sql
@@ -1,0 +1,4 @@
+DROP POLICY IF EXISTS page_views_select_exec_admin ON public.page_views;
+DROP POLICY IF EXISTS page_views_insert_public ON public.page_views;
+
+DROP TABLE IF EXISTS public.page_views;

--- a/packages/server/db/src/migrations/sqls/20260718000000-page-views-up.sql
+++ b/packages/server/db/src/migrations/sqls/20260718000000-page-views-up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE public.page_views (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  path TEXT NOT NULL,
+  visited_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  term_id UUID NOT NULL REFERENCES public.terms(id) ON DELETE RESTRICT,
+  visitor_id UUID NOT NULL,
+  user_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  CONSTRAINT page_views_path_starts_with_slash CHECK (path ~ '^/')
+);
+
+CREATE INDEX page_views_term_id_path_idx ON public.page_views (term_id, path);
+CREATE INDEX page_views_term_id_visited_at_idx ON public.page_views (term_id, visited_at DESC);
+
+ALTER TABLE public.page_views ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY page_views_insert_public ON public.page_views
+  FOR INSERT
+  WITH CHECK (
+    user_id IS NULL OR user_id = auth.uid()
+  );
+
+CREATE POLICY page_views_select_exec_admin ON public.page_views
+  FOR SELECT
+  USING (public.is_exec_or_admin(auth.uid()));

--- a/packages/server/db/src/migrations/sqls/20260718100000-page-views-log-rpc-down.sql
+++ b/packages/server/db/src/migrations/sqls/20260718100000-page-views-log-rpc-down.sql
@@ -1,0 +1,7 @@
+DROP FUNCTION IF EXISTS public.log_page_view(text, uuid);
+
+CREATE POLICY page_views_insert_public ON public.page_views
+  FOR INSERT
+  WITH CHECK (
+    user_id IS NULL OR user_id = auth.uid()
+  );

--- a/packages/server/db/src/migrations/sqls/20260718100000-page-views-log-rpc-up.sql
+++ b/packages/server/db/src/migrations/sqls/20260718100000-page-views-log-rpc-up.sql
@@ -1,0 +1,35 @@
+DROP POLICY IF EXISTS page_views_insert_public ON public.page_views;
+
+CREATE OR REPLACE FUNCTION public.log_page_view(
+  p_path text,
+  p_visitor_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_term_id uuid;
+BEGIN
+  IF p_path IS NULL OR btrim(p_path) = '' OR p_path !~ '^/' THEN
+    RETURN;
+  END IF;
+
+  IF p_visitor_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT id INTO v_term_id
+  FROM public.terms
+  WHERE is_active = true
+  LIMIT 1;
+
+  IF v_term_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.page_views (path, term_id, visitor_id, user_id)
+  VALUES (p_path, v_term_id, p_visitor_id, auth.uid());
+END;
+$$;


### PR DESCRIPTION
<!-- Make sure you add the correct **Assignees** and **Labels** that best fit this pull request -->

<!-- DO NOT forget to add the **label** corresponding to the **current term** (i.e. **W26**) -->

<!-- IMPORTANT: please replace "[issue-number]" with the issue number from the GitHub Project -->

## Closes Issue

closes #126 

<!-- Brief description of what you changed using bullet points -->

## Changes Made

- Added `page_views` table with `path`, `visited_at`, `term_id`, `visitor_id`, and nullable `user_id`, plus indexes for term-scoped top-pages queries
- Added `log_page_view` RPC that resolves the active term from `terms` and sets `user_id` from `auth.uid()` server-side
- Added `getOrCreateVisitorId()` to generate and persist a stable anonymous visitor ID in `localStorage`
- Added `PageViewTracker` client component that logs visits on pathname changes via `POST /api/analytics/page-view`
- Mounted `PageViewTracker` in `AppProviders` so anonymous and authenticated traffic are both tracked

## Additional Notes/Screenshots/Videos (Optional)

- Run `pnpm migrate` to apply `20260718000000-page-views` and `20260718100000-page-views-log-rpc`
- Example query for top pages in the active term:

```sql
SELECT path, COUNT(*) AS views
FROM public.page_views
WHERE term_id = (SELECT id FROM public.terms WHERE is_active = true)
GROUP BY path
ORDER BY views DESC;
